### PR TITLE
Update listening port

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With `lookout-sdk` binary from the latest release of [SDK](https://github.com/sr
 ```
 $ python3 flake8_analyzer.py
 
-$ lookout-sdk review -v ipv4://localhost:2001 \
+$ lookout-sdk review -v ipv4://localhost:2022 \
     --from c99dcdff172f1cb5505603a45d054998cb4dd606 \
     --to 3a9d78bdd1139c929903885ecb8f811931b8aa70
 ```
@@ -23,7 +23,7 @@ $ lookout-sdk review -v ipv4://localhost:2001 \
 | Variable | Default | Description |
 | -- | -- | -- |
 | `FLAKE8_HOST` | `0.0.0.0` | IP address to bind the gRPC serve |
-| `FLAKE8_PORT` | `2002` | Port to bind the gRPC server |
+| `FLAKE8_PORT` | `2022` | Port to bind the gRPC server |
 | `FLAKE8_DATA_SERVICE_URL` | `ipv4://localhost:10301` | gRPC URL of the [Data service](https://github.com/src-d/lookout/tree/master/docs#components)
 | `FLAKE8_LOG_LEVEL` | `info` | Logging level (info, debug, warning or error) |
 


### PR DESCRIPTION
It seems the analyzer is listening to `2022`; isn't it?
https://github.com/src-d/lookout-flake8-analyzer/blob/master/flake8_analyzer.py#L20